### PR TITLE
fix: update DockerHub image references to handle missing username gra…

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -43,7 +43,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          images: ${{ secrets.DOCKERHUB_USERNAME || 'testuser' }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -82,6 +82,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME || 'testuser' }}/${{ env.IMAGE_NAME }}
           short-description: 'A modern, minimal, high-performance, Rust-based file browser for web'
           readme-filepath: ./README.md


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-build-push.yml` file to add a fallback value for the Docker Hub username in case it is not provided via secrets. This ensures the workflow can run in environments where the `DOCKERHUB_USERNAME` secret is not set.

### Workflow improvements:

* Modified the `images` field in the `docker/metadata-action` step to use a fallback value of `'testuser'` for `DOCKERHUB_USERNAME` if the secret is not set. (`[.github/workflows/docker-build-push.ymlL46-R46](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L46-R46)`)
* Updated the `repository` field in the `docker/publish-action` step to use the same fallback logic for `DOCKERHUB_USERNAME`. (`[.github/workflows/docker-build-push.ymlL85-R85](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L85-R85)`)…cefully